### PR TITLE
Show time in hours, minutes and seconds

### DIFF
--- a/src/WorkCheckIn/WorkCheckIn.tsx
+++ b/src/WorkCheckIn/WorkCheckIn.tsx
@@ -166,8 +166,8 @@ export default function WorkCheckIn(): ReactElement {
           {workLogs.map((workLog) => (
             <Tr key={workLog.id}>
               <Td>{moment(workLog.date).format('dddd YYYY-MM-DD')}</Td>
-              <Td isNumeric>{Calculator.getHoursBySeconds(workLog.workTimeInSeconds)}</Td>
-              <Td isNumeric>{Calculator.getHoursBySeconds(workLog.pausedWorkTimeInSeconds)}</Td>
+              <Td isNumeric>{formatTime?.(workLog.workTimeInSeconds)}</Td>
+              <Td isNumeric>{formatTime?.(workLog.pausedWorkTimeInSeconds)}</Td>
             </Tr>
           ))}
         </Tbody>


### PR DESCRIPTION
https://trello.com/c/0g1ozcmU/41-41-show-work-log-time-in-hours-and-minutes-instead-of-86